### PR TITLE
add Cask for tailscale

### DIFF
--- a/Casks/zcutlip-tailscale.rb
+++ b/Casks/zcutlip-tailscale.rb
@@ -1,0 +1,46 @@
+cask "zcutlip-tailscale" do
+  version "1.32.3"
+  sha256 "aba516693c71188865e9034fdc8b1616bb9b3ea0872a18a8d54463d000f32d6a"
+
+  url "https://pkgs.tailscale.com/stable/Tailscale-#{version}-macos.zip"
+  name "zcutlip-tailscale"
+  desc "Mesh VPN based on Wireguard"
+  homepage "https://tailscale.com/"
+
+  livecheck do
+    # url "https://pkgs.tailscale.com/stable/appcast.xml"
+    # strategy :sparkle, &:short_version
+    skip # we want to specificcally pin this to the current version due to DNS scoping issues
+  end
+
+  auto_updates true
+  conflicts_with formula: "tailscale"
+  depends_on macos: ">= :catalina"
+
+  app "Tailscale.app"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/tailscale.wrapper.sh"
+  binary shimscript, target: "tailscale"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/Tailscale.app/Contents/MacOS/Tailscale' "$@"
+    EOS
+  end
+
+  uninstall login_item: "Tailscale",
+            quit:       "io.tailscale.ipn.macsys"
+
+  zap trash: [
+    "Library/Tailscale",
+    "~/Library/Application Scripts/*.io.tailscale.ipn.macsys",
+    "~/Library/Application Scripts/io.tailscale.ipn.macsys.share-extension",
+    "~/Library/Application Scripts/io.tailscale.ipn.macsys",
+    "~/Library/Containers/io.tailscale.ipn.macos.network-extension",
+    "~/Library/Containers/io.tailscale.ipn.macsys.share-extension",
+    "~/Library/Containers/io.tailscale.ipn.macsys",
+    "~/Library/Containers/Tailscale",
+    "~/Library/Group Containers/*.io.tailscale.ipn.macsys",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -23,7 +23,25 @@ _Install_
 `brew install --cask zcutlip/extras/zcutlip-dockutil`
 
 _Notes_
+
 - Requires macOS Big Sur or later
 - If the pure-python 'dockutil' is installed from the homebrew formula or elswewhere, be sure to uninstall it first:
   - `brew uninstall dockutil`
 
+**`zcutlip-tailscale`**
+
+_Description_
+
+Mesh VPN based on Wireguard.
+
+The purpose of this Cask is to install an earlier version of Tailscale due to a DNS scoping issue in 1.34
+
+_Install_
+
+`brew install --cask zcutlip/extras/zcutlip-tailscale`
+
+_Notes_
+
+- Requires macOS Catalina or later
+- This cask is specifically pinned to version 1.32.3
+- This cask will be removed once the DNS issue referenced above is addressed


### PR DESCRIPTION
tailscale cask pinned to version 1.32.3 due to DNS scoping issues in 1.34.x